### PR TITLE
Miscellaneous improvements, including universal spline object and removing rigid body ground bouncing

### DIFF
--- a/grips.js
+++ b/grips.js
@@ -1,4 +1,5 @@
 import {tiny, defs} from './examples/common.js';
+import {spls} from './spline.js';
 
 // Pull these names into this module's scope for convenience:
 const { vec3, vec4, color, hex_color, Mat4, Shape, Material, Shader, Texture, Component } = tiny;
@@ -7,10 +8,10 @@ export const grips = {};
 
 const ball = new defs.Subdivision_Sphere( 5 );
 const material_grip = { shader: new defs.Phong_Shader(), ambient: .2, diffusivity: 1, specularity: .5, color: color( .9,.5,.9,1 ) };
-
 const Grip = grips.Grip = class Grip {
-    constructor(spline, t, omega) {
-        this.spline = spline;
+    constructor(catmull_pts, transform_matrix, t, omega) {
+        this.catmull_pts = catmull_pts;
+        this.transform_matrix = transform_matrix;
         this.t = t;
         this.omega = omega;
         this.shape = ball;
@@ -18,8 +19,18 @@ const Grip = grips.Grip = class Grip {
         this.color = hex_color("#ee9494");
     }
 
-    position() {
-        return this.spline.curr_pos( (Math.sin(this.omega * this.t) + 1) / 2);
+    position(hermite_spline) {
+        hermite_spline.transform_matrix = this.transform_matrix;
+        hermite_spline.catmull_ctrl_points(this.catmull_pts);
+        return hermite_spline.curr_pos( (Math.sin(this.omega * this.t) + 1) / 2);
+    }
+
+    draw( hermite_spline, caller, uniforms, base_transform ) {
+        this.shape.draw( caller, uniforms, base_transform
+                .times(Mat4.translation(...this.position(hermite_spline)))
+                .times(Mat4.scale(0.3, 0.3, 0.3))
+            , {...material_grip, color: this.color});
+        hermite_spline.sync_draw( caller, uniforms, base_transform);
     }
 };
 
@@ -29,8 +40,8 @@ const Grips = grips.Grips = class Grips extends Array {
         this.height = height;
     }
 
-    add_grip(spline, init_t, omega) {
-        let grip = new Grip(spline, init_t, omega);
+    add_grip(catmull_pts, transform_matrix, init_t, omega) {
+        let grip = new Grip(catmull_pts, transform_matrix, init_t, omega);
         this.push(grip);
     }
 
@@ -40,12 +51,12 @@ const Grips = grips.Grips = class Grips extends Array {
         }
     }
 
-    update(dh, dt) {
+    update(hermite_spline, dh, dt) {
         let counter = 0;
         this.height += dh;
         for (let i = this.length-1; i >= 0; i--) {
             this[i].t += dt * this[i].omega;
-            if (this[i].position()[1] < this.height - 20 /* TODO: so does here: change to some calculated value */) {
+            if (this[i].position(hermite_spline)[1] < this.height - 10 /* TODO: so does here: change to some calculated value */) {
                 if (this[i].grabable) counter++;
                 this.remove_grip(i);
             }
@@ -53,38 +64,34 @@ const Grips = grips.Grips = class Grips extends Array {
         return counter;
     }
 
-    position_list() {
+    position_list(hermite_spline) {
         let pos_list = [];
         for (let grip of this) {
-            pos_list.push(Mat4.translation(0, -this.height, 0).times(grip.position().to4(true)).to3());
+            pos_list.push(Mat4.translation(0, -this.height, 0).times(grip.position(hermite_spline).to4(true)).to3());
         }
         return pos_list;
     }
 
-    find_closest(pos) {
-        let pos_list = this.position_list();
+    find_closest(hermite_spline, pos) {
+        let pos_list = this.position_list(hermite_spline);
         let min_dist = -1;
         let closest_grip = null;
         for (let grip of this) {
-            let grip_pos = Mat4.translation(0, -this.height, 0).times(grip.position().to4(true)).to3();
+            let grip_pos = Mat4.translation(0, -this.height, 0).times(grip.position(hermite_spline).to4(true)).to3();
             let dist = vec3(...pos).minus(vec3(...grip_pos)).norm();
             if (min_dist < 0 || dist < min_dist) {
                 min_dist = dist;
                 closest_grip = grip;
             }
         }
-        const position = closest_grip.position();
+        const position = closest_grip.position(hermite_spline);
         position[1] -= this.height;
         return { grip: closest_grip, position: position, min_dist: min_dist };
     }
 
-    draw( caller, uniforms ) {
+    draw( hermite_spline, caller, uniforms ) {
         for (let grip of this) {
-            grip.shape.draw( caller, uniforms, Mat4.translation(0, -this.height, 0)
-                                            .times(Mat4.translation(...grip.position()))
-                                            .times(Mat4.scale(0.3, 0.3, 0.3))
-                , {...material_grip, color: grip.color});
-            grip.spline.sync_draw( caller, uniforms, Mat4.translation(0, -this.height, 0) );
+            grip.draw( hermite_spline, caller, uniforms, Mat4.translation(0, -this.height, 0));
         }
     }
 }

--- a/rigidbody.js
+++ b/rigidbody.js
@@ -132,9 +132,9 @@ class Rigidbody
         this.p = this.p.plus(ds[2].times(dt));
         this.r = this.r.plus(ds[3].times(dt));
 
-        if(this.x[1] < 0 && this.hit_ground_callback)
-        {
-            this.hit_ground_callback();
-        }
+        // if(this.x[1] < 0 && this.hit_ground_callback)
+        // {
+        //     this.hit_ground_callback();
+        // }
     }
 }

--- a/spline.js
+++ b/spline.js
@@ -171,7 +171,7 @@ const Hermite_Spline = spls.Hermite_Spline =
             }
         }
 
-        set_ctrl_points(pts) {
+        catmull_ctrl_points(pts) {
             // set points according to Catmull-Rom rule
             this.ctrl_pts = [];
             this.ctrl_tgs = [];


### PR DESCRIPTION
Used the same spline each time drawing the grip spline, so that there won't be too many shapes copied onto graphics card; now rigid bodies will not bounce up when hitting bottom of camera, and will be removed once it moves low enough; now rigid bodies support pause (i.e. will stay still and won't reduce lifetime upon pausing)